### PR TITLE
[YSS-27] 유저 정보 조회, 수정

### DIFF
--- a/yakssok/src/main/java/server/yakssok/domain/auth/presentation/controller/AuthController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/auth/presentation/controller/AuthController.java
@@ -64,7 +64,8 @@ public class AuthController {
 	@ApiErrorResponse(ErrorCode.INVALID_JWT)
 	@PutMapping("/logout")
 	public ApiResponse logout(@AuthenticationPrincipal UserDetails userDetails) {
-		authService.logOut(Long.valueOf(userDetails.getUsername()));
+		Long userId = Long.valueOf(userDetails.getUsername());
+		authService.logOut(userId);
 		return ApiResponse.success();
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserService.java
@@ -1,0 +1,41 @@
+package server.yakssok.domain.user.application.service;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import server.yakssok.domain.user.application.exception.UserException;
+import server.yakssok.domain.user.domain.entity.User;
+import server.yakssok.domain.user.domain.repository.UserRepository;
+import server.yakssok.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import server.yakssok.domain.user.presentation.dto.response.FindUserInfoResponse;
+import server.yakssok.global.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+
+	@Transactional
+	public FindUserInfoResponse findUserInfo(Long userId) {
+		User user = getUser(userId);
+		return new FindUserInfoResponse(
+			user.getNickName(),
+			user.getProfileImageUrl()
+		);
+	}
+
+	@Transactional
+	public void updateUserInfo(Long userId, UpdateUserInfoRequest userInfoRequest) {
+		User user = getUser(userId);
+		user.updateInfo(
+			userInfoRequest.nickname(),
+			userInfoRequest.profileImageUrl()
+		);
+	}
+
+	private User getUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+	}
+}

--- a/yakssok/src/main/java/server/yakssok/domain/user/domain/entity/User.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/domain/entity/User.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.yakssok.domain.BaseEntity;
@@ -61,5 +60,10 @@ public class User extends BaseEntity {
 
 	public void updateFcmToken(String fcmToken) {
 		this.fcmToken = fcmToken;
+	}
+
+	public void updateInfo(String nickname, String profileImageUrl) {
+		this.nickName = nickname;
+		this.profileImageUrl = profileImageUrl;
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/presentation/controller/UserController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/presentation/controller/UserController.java
@@ -1,0 +1,50 @@
+package server.yakssok.domain.user.presentation.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import server.yakssok.domain.user.application.service.UserService;
+import server.yakssok.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import server.yakssok.domain.user.presentation.dto.response.FindUserInfoResponse;
+import server.yakssok.global.ApiResponse;
+import server.yakssok.global.common.swagger.ApiErrorResponse;
+import server.yakssok.global.exception.ErrorCode;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Tag(name = "User", description = "유저 API")
+public class UserController {
+	private final UserService userService;
+
+	@Operation(summary = "유저 정보 조회(프로필, 닉네임)")
+	@ApiErrorResponse(ErrorCode.NOT_FOUND_USER)
+	@GetMapping("/me")
+	public ApiResponse<FindUserInfoResponse> findUserInfo(
+		@AuthenticationPrincipal UserDetails userDetails
+	) {
+		Long userId = Long.valueOf(userDetails.getUsername());
+		return ApiResponse.success(userService.findUserInfo(userId));
+	}
+
+	@Operation(summary = "유저 정보 수정(프로필, 닉네임)")
+	@ApiErrorResponse(ErrorCode.NOT_FOUND_USER)
+	@PutMapping("/me")
+	public ApiResponse updateUserInfo(
+		@Valid @RequestBody UpdateUserInfoRequest userInfoRequest,
+		@AuthenticationPrincipal UserDetails userDetails
+	) {
+		Long userId = Long.valueOf(userDetails.getUsername());
+		userService.updateUserInfo(userId, userInfoRequest);
+		return ApiResponse.success();
+	}
+}

--- a/yakssok/src/main/java/server/yakssok/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
@@ -1,0 +1,14 @@
+package server.yakssok.domain.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record UpdateUserInfoRequest(
+	@Schema(description = "수정할 닉네임", example = "노을")
+	@NotEmpty
+	String nickname,
+
+	@Schema(description = "수정할 프로필 링크 (기본프로필은 null)", example = "https://example.com/profile.jpg")
+	String profileImageUrl
+) {
+}

--- a/yakssok/src/main/java/server/yakssok/domain/user/presentation/dto/response/FindUserInfoResponse.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/presentation/dto/response/FindUserInfoResponse.java
@@ -1,0 +1,7 @@
+package server.yakssok.domain.user.presentation.dto.response;
+
+public record FindUserInfoResponse(
+	String nickname,
+	String profileImageUrl
+) {
+}

--- a/yakssok/src/main/java/server/yakssok/global/common/swagger/SwaggerConfig.java
+++ b/yakssok/src/main/java/server/yakssok/global/common/swagger/SwaggerConfig.java
@@ -3,6 +3,7 @@ package server.yakssok.global.common.swagger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -17,7 +18,7 @@ public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI openAPI() {
-		final String securitySchemeName = "bearerAuth";
+		final String securitySchemeName = "Authorization";
 
 		return new OpenAPI()
 			.addServersItem(new Server().url(swaggerProperties.serverUrl()))
@@ -26,7 +27,7 @@ public class SwaggerConfig {
 				.description("약속 API 문서")
 				.version("v1"))
 			.addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
-			.components(new io.swagger.v3.oas.models.Components()
+			.components(new Components()
 				.addSecuritySchemes(securitySchemeName,
 					new SecurityScheme()
 						.name(securitySchemeName)
@@ -34,7 +35,6 @@ public class SwaggerConfig {
 						.scheme("bearer")
 						.bearerFormat("JWT")));
 	}
-
 	@Bean
 	public ApiErrorResponseCustomizer apiErrorResponseCustomizer() {
 		return new ApiErrorResponseCustomizer();


### PR DESCRIPTION

## 💻 작업 내용
유저 정보 수정, 유저 정보 조회
- 유저 프로필은 기본 프로필일 경우에 null 응답함. 
- 클라이언트에서 인터넷이 끊겨도 프로필 사진을 보여줘야 하기 때문에 사진을 들고 있는 게 좋을 것 같기 때문에~ 

## 🗒️ 참고자료
