### PR TITLE
[YSS-38] 복약 루틴 종료

### DIFF
--- a/yakssok/src/main/java/server/yakssok/domain/feeback/domain/entity/Feedback.java
+++ b/yakssok/src/main/java/server/yakssok/domain/feeback/domain/entity/Feedback.java
@@ -18,7 +18,6 @@ import server.yakssok.domain.user.domain.entity.User;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Feedback {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/yakssok/src/main/java/server/yakssok/domain/friend/domain/entity/Friend.java
+++ b/yakssok/src/main/java/server/yakssok/domain/friend/domain/entity/Friend.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Friend {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationScheduleGenerator.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationScheduleGenerator.java
@@ -1,6 +1,7 @@
 package server.yakssok.domain.medication.application.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -56,14 +57,14 @@ public class MedicationScheduleGenerator {
 	}
 
 	private LocalDate getActualEnd(LocalDate inputEnd, Medication medication) {
-		LocalDate routineEnd = medication.getEndDate();
-		return (routineEnd == null) ? inputEnd : (inputEnd.isBefore(routineEnd) ? inputEnd : routineEnd);
+		LocalDate endDate = medication.getEndDate();
+		return (endDate == null) ? inputEnd : (inputEnd.isBefore(endDate) ? inputEnd : endDate);
 	}
 
-	public List<MedicationSchedule> generateTodaySchedules(LocalDate today) {
-		List<MedicationDto> medicationDtos = medicationRepository.findMedicationsByDate(today, today.getDayOfWeek());
+	public List<MedicationSchedule> generateTodaySchedules(LocalDateTime currentDateTime) {
+		List<MedicationDto> medicationDtos = medicationRepository.findMedicationsByDate(currentDateTime, currentDateTime.getDayOfWeek());
 		return medicationDtos.stream()
-			.map(dto -> MedicationSchedule.create(today, dto.intakeTime(), dto.medicationId()))
+			.map(dto -> MedicationSchedule.create(currentDateTime.toLocalDate(), dto.intakeTime(), dto.medicationId()))
 			.toList();
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationService.java
@@ -1,6 +1,7 @@
 package server.yakssok.domain.medication.application.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -64,10 +65,9 @@ public class MedicationService {
 	@Transactional
 	public void endMedication(Long medicationId) {
 		Medication medication = getMedication(medicationId);
-		LocalDate todayDate = LocalDate.now();
-		LocalTime currentTime = LocalTime.now();
-		medication.changeEndDate(todayDate);
-		deleteTodayUpcomingSchedules(medicationId, todayDate, currentTime);
+		LocalDateTime currentDateTime = LocalDateTime.now();
+		medication.end(currentDateTime);
+		deleteTodayUpcomingSchedules(medicationId, currentDateTime.toLocalDate(), currentDateTime.toLocalTime());
 	}
 
 	private Medication getMedication(Long medicationId) {
@@ -76,7 +76,7 @@ public class MedicationService {
 		return medication;
 	}
 
-	private void deleteTodayUpcomingSchedules(Long medicationId, LocalDate todayDate, LocalTime currentTime) {
-		medicationScheduleRepository.deleteTodayUpcomingSchedules(medicationId, todayDate, currentTime);
+	private void deleteTodayUpcomingSchedules(Long medicationId, LocalDate currentDate, LocalTime currentTime) {
+		medicationScheduleRepository.deleteTodayUpcomingSchedules(medicationId, currentDate, currentTime);
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationUtils.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationUtils.java
@@ -1,0 +1,11 @@
+package server.yakssok.domain.medication.application.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class MedicationUtils {
+	public static LocalDateTime toEndOfDay(LocalDate endDate) {
+		return LocalDateTime.of(endDate, LocalTime.of(23, 59, 59));
+	}
+}

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/Medication.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/Medication.java
@@ -101,7 +101,7 @@ public class Medication {
 		if (isNotExistEndDate() || !now.isAfter(endDateTime)) {
 			return MedicationStatus.TAKING;
 		}
-		return MedicationStatus.COMPLETED;
+		return MedicationStatus.ENDED;
 	}
 
 	private boolean isNotExistEndDate() {

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/Medication.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/Medication.java
@@ -93,14 +93,22 @@ public class Medication {
 		LocalDate today = LocalDate.now();
 		if (today.isBefore(startDate)) {
 			return MedicationStatus.PLANNED;
-		} else if (!today.isAfter(endDate)) {
+		} else if (isNotExistEndDate() || !today.isAfter(endDate)) {
 			return MedicationStatus.TAKING;
 		} else {
 			return MedicationStatus.COMPLETED;
 		}
 	}
 
+	private boolean isNotExistEndDate() {
+		return this.endDate == null;
+	}
+
 	public MedicationStatus getMedicationStatus() {
 		return calculateStatus(startDate, endDate);
+	}
+
+	public void changeEndDate(LocalDate date) {
+		this.endDate = date;
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/Medication.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/Medication.java
@@ -30,7 +30,7 @@ public class Medication {
 	private String medicineName;
 
 	@Column(nullable = false)
-	private LocalDate startDate;
+	private LocalDateTime startDateTime;
 	private LocalDateTime endDateTime;
 
 	@Column(nullable = false)
@@ -53,7 +53,7 @@ public class Medication {
 
 	private Medication(
 		String medicineName,
-		LocalDate startDate,
+		LocalDateTime startDateTime,
 		LocalDateTime endDateTime,
 		AlarmSound alarmSound,
 		MedicationType medicationType,
@@ -61,7 +61,7 @@ public class Medication {
 		int intakeCount
 	) {
 		this.medicineName = medicineName;
-		this.startDate = startDate;
+		this.startDateTime = startDateTime;
 		this.endDateTime = endDateTime;
 		this.alarmSound = alarmSound;
 		this.medicationType = medicationType;
@@ -71,6 +71,10 @@ public class Medication {
 
 	private static LocalDateTime convertToEndDateTime(LocalDate endDate) {
 		return endDate == null ? null : MedicationUtils.toEndOfDay(endDate);
+	}
+
+	private static LocalDateTime convertToStartDateTime(LocalDate startDate) {
+		return startDate.atStartOfDay();
 	}
 
 	public static Medication create(
@@ -84,7 +88,7 @@ public class Medication {
 	) {
 		return new Medication(
 			medicineName,
-			startDate,
+			convertToStartDateTime(startDate),
 			convertToEndDateTime(endDate),
 			alarmSound,
 			medicationType,
@@ -93,9 +97,9 @@ public class Medication {
 		);
 	}
 
-	private MedicationStatus calculateStatus(LocalDate startDate, LocalDateTime endDateTime) {
+	private MedicationStatus calculateStatus(LocalDateTime startDateTime, LocalDateTime endDateTime) {
 		LocalDateTime now = LocalDateTime.now();
-		if (now.toLocalDate().isBefore(startDate)) {
+		if (now.isBefore(startDateTime)) {
 			return MedicationStatus.PLANNED;
 		}
 		if (isNotExistEndDate() || !now.isAfter(endDateTime)) {
@@ -109,7 +113,7 @@ public class Medication {
 	}
 
 	public MedicationStatus getMedicationStatus() {
-		return calculateStatus(startDate, endDateTime);
+		return calculateStatus(startDateTime, endDateTime);
 	}
 
 	public void end(LocalDateTime endDateTime) {
@@ -118,5 +122,9 @@ public class Medication {
 
 	public LocalDate getEndDate() {
 		return endDateTime == null ? null : endDateTime.toLocalDate();
+	}
+
+	public LocalDate getStartDate() {
+		return startDateTime.toLocalDate();
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/MedicationStatus.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/entity/MedicationStatus.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 public enum MedicationStatus {
 	PLANNED,
 	TAKING,
-	COMPLETED;
+	ENDED;
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationQueryRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationQueryRepository.java
@@ -1,7 +1,7 @@
 package server.yakssok.domain.medication.domain.repository;
 
 import java.time.DayOfWeek;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import server.yakssok.domain.medication.domain.entity.Medication;
@@ -10,6 +10,6 @@ import server.yakssok.domain.medication.domain.repository.dto.MedicationDto;
 
 public interface MedicationQueryRepository {
 	List<Medication> findAllUserMedications(Long userId);
-	List<MedicationDto> findMedicationsByDate(LocalDate date, DayOfWeek dayOfWeek);
+	List<MedicationDto> findMedicationsByDate(LocalDateTime dateTime, DayOfWeek dayOfWeek);
 	List<FutureMedicationSchedulesDto> findFutureMedicationSchedules(Long userId);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationQueryRepositoryImpl.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationQueryRepositoryImpl.java
@@ -48,7 +48,7 @@ public class MedicationQueryRepositoryImpl implements MedicationQueryRepository{
 			.join(medication.intakeDays, medicationIntakeDay)
 			.join(medication.intakeTimes, medicationIntakeTime)
 			.where(
-				isMedicationStarted(dateTime.toLocalDate()),
+				isMedicationStarted(dateTime),
 				isMedicationNotEnded(dateTime),
 				isIntakeDayOfWeek(dayOfWeek)
 			)
@@ -73,8 +73,8 @@ public class MedicationQueryRepositoryImpl implements MedicationQueryRepository{
 			.fetch();
 	}
 
-	private BooleanExpression isMedicationStarted(LocalDate targetDate) {
-		return medication.startDate.loe(targetDate);
+	private BooleanExpression isMedicationStarted(LocalDateTime dateTime) {
+		return medication.startDateTime.loe(dateTime);
 	}
 
 	private BooleanExpression isMedicationNotEnded(LocalDateTime dateTime) {

--- a/yakssok/src/main/java/server/yakssok/domain/medication/presentation/controller/MedicationController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/presentation/controller/MedicationController.java
@@ -2,7 +2,9 @@ package server.yakssok.domain.medication.presentation.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,12 +15,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import server.yakssok.domain.medication.application.service.MedicationService;
 import server.yakssok.domain.medication.presentation.dto.request.CreateMedicationRequest;
-import server.yakssok.domain.medication.presentation.dto.response.MedicationCardResponse;
 import server.yakssok.domain.medication.presentation.dto.response.MedicationGroupedResponse;
 import server.yakssok.global.common.reponse.ApiResponse;
-import server.yakssok.global.common.reponse.PageResponse;
 import server.yakssok.global.common.security.YakssokUserDetails;
 import server.yakssok.global.common.swagger.ApiErrorResponse;
+import server.yakssok.global.common.swagger.ApiErrorResponses;
 import server.yakssok.global.exception.ErrorCode;
 
 @RestController
@@ -47,5 +48,15 @@ public class MedicationController {
 	) {
 		Long userId = userDetails.getUserId();
 		return ApiResponse.success(medicationService.findMedications(userId));
+	}
+
+	@Operation(summary = "복약 종료")
+	@ApiErrorResponse(ErrorCode.NOT_FOUND_MEDICATION)
+	@PutMapping("/{medicationId}/end")
+	public ApiResponse endMedication(
+		@PathVariable Long medicationId
+	) {
+		medicationService.endMedication(medicationId);
+		return ApiResponse.success();
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/presentation/dto/request/CreateMedicationRequest.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/presentation/dto/request/CreateMedicationRequest.java
@@ -21,10 +21,10 @@ public record CreateMedicationRequest(
 	String medicineType,
 
 	@Schema(description = "복용 시작일 (yyyy-MM-dd)", example = "2025-07-06")
-	String startDate,
+	LocalDate startDate,
 
 	@Schema(description = "복용 종료일 (yyyy-MM-dd)", example = "2025-07-13")
-	String endDate,
+	LocalDate endDate,
 
 	@Schema(
 		description = "복용 요일",
@@ -33,7 +33,7 @@ public record CreateMedicationRequest(
 	)
 	List<String> intakeDays,
 
-	@Schema(description = "하루 복용 횟수", example = "1")
+	@Schema(description = "하루 복용 횟수", example = "2")
 	Integer intakeCount,
 
 	@Schema(description = "알람 종류", example = "FEEL_GOOD")
@@ -41,16 +41,16 @@ public record CreateMedicationRequest(
 
 	@Schema(
 		description = "복용 시간",
-		example = "[\"08:00\", \"13:00\"]"
+		example = "[\"08:00:00\", \"13:00:00\"]"
 	)
-	List<String> intakeTimes
+	List<LocalTime> intakeTimes
 ) {
 
 	public Medication toMedication(Long userId) {
 		return Medication.create(
 			name,
-			LocalDate.parse(startDate),
-			LocalDate.parse(endDate),
+			startDate,
+			endDate,
 			AlarmSound.from(alarmSound),
 			MedicationType.from(medicineType),
 			userId,
@@ -61,7 +61,7 @@ public record CreateMedicationRequest(
 	public List<MedicationIntakeTime> toMedicationsTimes(Medication medication){
 		return intakeTimes.stream()
 			.map(intakeTime -> MedicationIntakeTime.create(
-				LocalTime.parse(intakeTime), medication
+				intakeTime, medication
 			))
 			.toList();
 	}

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleService.java
@@ -24,12 +24,12 @@ public class MedicationScheduleService {
 	private final MedicationScheduleJdbcRepository medicationScheduleJdbcRepository;
 	private final MedicationScheduleRepository medicationScheduleRepository;
 	private final MedicationScheduleFinder medicationScheduleFinder;
-	private final MedicationScheduleGenerator MedicationScheduleGenerator;
+	private final MedicationScheduleGenerator medicationScheduleGenerator;
 
 	@Transactional
 	public void generateTodaySchedules() {
 		LocalDate today = LocalDate.now();
-		List<MedicationSchedule> schedules = MedicationScheduleGenerator.generateTodaySchedules(today);
+		List<MedicationSchedule> schedules = medicationScheduleGenerator.generateTodaySchedules(today);
 		medicationScheduleJdbcRepository.batchInsert(schedules);
 	}
 
@@ -57,6 +57,9 @@ public class MedicationScheduleService {
 		LocalDate start = LocalDate.parse(startDate);
 		LocalDate end = LocalDate.parse(endDate);
 		LocalDate today = LocalDate.now();
+		if (start.isAfter(end)) {
+			throw new MedicationScheduleException(ErrorCode.INVALID_INPUT_VALUE);
+		}
 
 		List<MedicationScheduleDto> schedules =
 			medicationScheduleFinder.findSchedulesInPeriod(userId, start, end, today);

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleService.java
@@ -1,6 +1,7 @@
 package server.yakssok.domain.medication_schedule.application.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
@@ -28,8 +29,8 @@ public class MedicationScheduleService {
 
 	@Transactional
 	public void generateTodaySchedules() {
-		LocalDate today = LocalDate.now();
-		List<MedicationSchedule> schedules = medicationScheduleGenerator.generateTodaySchedules(today);
+		LocalDateTime currentDateTime = LocalDateTime.now();
+		List<MedicationSchedule> schedules = medicationScheduleGenerator.generateTodaySchedules(currentDateTime);
 		medicationScheduleJdbcRepository.batchInsert(schedules);
 	}
 

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/entity/MedicationSchedule.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/entity/MedicationSchedule.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class MedicationSchedule {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepository.java
@@ -1,6 +1,7 @@
 package server.yakssok.domain.medication_schedule.domain.repository;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import server.yakssok.domain.medication_schedule.domain.repository.dto.MedicationScheduleDto;
@@ -8,4 +9,5 @@ import server.yakssok.domain.medication_schedule.domain.repository.dto.Medicatio
 public interface MedicationScheduleQueryRepository {
 	List<MedicationScheduleDto> findUserScheduleByDate(Long userId, LocalDate date);
 	List<MedicationScheduleDto> findSchedulesInPastRange(Long userId, LocalDate startDate, LocalDate endDate);
+	void deleteTodayUpcomingSchedules(Long medicationId, LocalDate todayDate, LocalTime currentTime);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepository.java
@@ -9,5 +9,5 @@ import server.yakssok.domain.medication_schedule.domain.repository.dto.Medicatio
 public interface MedicationScheduleQueryRepository {
 	List<MedicationScheduleDto> findUserScheduleByDate(Long userId, LocalDate date);
 	List<MedicationScheduleDto> findSchedulesInPastRange(Long userId, LocalDate startDate, LocalDate endDate);
-	void deleteTodayUpcomingSchedules(Long medicationId, LocalDate todayDate, LocalTime currentTime);
+	void deleteTodayUpcomingSchedules(Long medicationId, LocalDate currentDate, LocalTime currentTime);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepositoryImpl.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import static server.yakssok.domain.medication.domain.entity.QMedication.*;
 import static server.yakssok.domain.medication_schedule.domain.entity.QMedicationSchedule.*;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import com.querydsl.core.types.Projections;
@@ -65,5 +66,17 @@ public class MedicationScheduleQueryRepositoryImpl implements MedicationSchedule
 				medicationSchedule.scheduledDate.loe(endDate)
 			)
 			.fetch();
+	}
+
+	@Override
+	public void deleteTodayUpcomingSchedules(Long medicationId, LocalDate todayDate, LocalTime currentTime) {
+		jpaQueryFactory
+			.delete(medicationSchedule)
+			.where(
+				medicationSchedule.medicationId.eq(medicationId),
+				medicationSchedule.scheduledDate.eq(todayDate),
+				medicationSchedule.scheduledTime.after(currentTime)
+			)
+			.execute(); // 삭제된 row 개수 리턴
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/global/exception/ErrorCode.java
+++ b/yakssok/src/main/java/server/yakssok/global/exception/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode implements ResponseCode{
     CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, 4001, "자기 자신을 친구로 추가할 수 없습니다."),
 
     // medication
-    NOT_FOUND_MEDICATION_SCHEDULE(HttpStatus.NOT_FOUND, 5000, "존재하지 않는 복약 스케줄입니다."),
+    NOT_FOUND_MEDICATION(HttpStatus.NOT_FOUND, 5000, "존재하지 않는 복약 스케줄입니다."),
+    NOT_FOUND_MEDICATION_SCHEDULE(HttpStatus.NOT_FOUND, 5001, "존재하지 않는 복약 스케줄입니다."),
 
 
     //common
@@ -35,7 +36,8 @@ public enum ErrorCode implements ResponseCode{
     FAILED_FILE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, 9100, "이미지 업로드에 실패했습니다."),
     FAILED_FILE_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, 9101, "이미지 삭제에 실패했습니다."),
     UNSUPPORTED_FILE_TYPE(HttpStatus.BAD_REQUEST, 9102, "지원하지 않는 파일 타입입니다."),
-    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 9103, "지원하지 않는 파일 확장자입니다.");
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 9103, "지원하지 않는 파일 확장자입니다."),
+    ;
 
 
 


### PR DESCRIPTION
## 💻 작업 내용
- 복약 루틴 종료 시 종료일을 현재 시점으로 저장함 
- 복약 종료한 순간부터 복약 종료 상태로 보여야 함 ➡️ 시간 관리하기 위해 LocalTime 필드 추가

- 복약 엔티티에 LocalTime과 LocalDate를 따로 관리하는 방법도 있었지만..! 간단한 쿼리를 위해 LocalDateTime으로 변경
- 복약 스케줄은 생성과 조회에서 날짜와 시간을 따로 다룰 일이 많아서 그대로 LocalDate, LocalTime 필드 유지
<img width="1918" height="842" alt="image" src="https://github.com/user-attachments/assets/b429218b-a949-486a-a504-364844aa11a3" />

