### PR TITLE
[YSS-57] 회원 탈퇴

### DIFF
--- a/yakssok/src/main/java/server/yakssok/domain/auth/application/service/RefreshTokenService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/auth/application/service/RefreshTokenService.java
@@ -27,6 +27,6 @@ public class RefreshTokenService {
 	}
 
 	public void deleteRefreshToken(Long userId) {
-		refreshTokenRepository.deleteByUserId(userId);
+		refreshTokenRepository.deleteAllByUserId(userId);
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/auth/domain/repository/RefreshTokenRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/auth/domain/repository/RefreshTokenRepository.java
@@ -3,11 +3,15 @@ package server.yakssok.domain.auth.domain.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import server.yakssok.domain.auth.domain.entity.RefreshToken;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 	Optional<RefreshToken> findByUserId(Long userId);
-	void deleteByUserId(Long userId);
+	@Modifying
+	@Query("DELETE FROM RefreshToken r WHERE r.user.id = :userId")
+	void deleteAllByUserId(Long userId);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/feeback/application/service/FeedbackService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/feeback/application/service/FeedbackService.java
@@ -24,8 +24,8 @@ public class FeedbackService {
 
 	@Transactional
 	public void sendFeedback(Long userId, CreateFeedbackRequest request) {
-		User sender = userService.getUserByUserId(userId);
-		User receiver = userService.getUserByUserId(request.receiverId());
+		User sender = userService.getActiveUser(userId);
+		User receiver = userService.getActiveUser(request.receiverId());
 		relationshipService.validateFriendship(sender.getId(), receiver.getId());
 		Feedback feedback = request.toFeedback(sender, receiver);
 		feedbackRepository.save(feedback);

--- a/yakssok/src/main/java/server/yakssok/domain/feeback/presentation/controller/FeedbackController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/feeback/presentation/controller/FeedbackController.java
@@ -1,7 +1,7 @@
 package server.yakssok.domain.feeback.presentation.controller;
 
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +15,7 @@ import server.yakssok.domain.feeback.presentation.dto.request.CreateFeedbackRequ
 import server.yakssok.global.common.reponse.ApiResponse;
 import server.yakssok.global.common.security.YakssokUserDetails;
 import server.yakssok.global.common.swagger.ApiErrorResponse;
+import server.yakssok.global.common.swagger.ApiErrorResponses;
 import server.yakssok.global.exception.ErrorCode;
 
 @Tag(name = "Feedback", description = "피드백 API")
@@ -25,7 +26,10 @@ public class FeedbackController {
 	private final FeedbackService feedbackService;
 
 	@Operation(summary = "피드백(잔소리/칭찬) 보내기")
-	@ApiErrorResponse(value = ErrorCode.INVALID_INPUT_VALUE)
+	@ApiErrorResponses(value = {
+		@ApiErrorResponse(ErrorCode.NOT_FRIEND),
+		@ApiErrorResponse(ErrorCode.INVALID_INPUT_VALUE)
+	})
 	@PostMapping
 	public ApiResponse sendFeedback(
 		@RequestBody CreateFeedbackRequest request,

--- a/yakssok/src/main/java/server/yakssok/domain/friend/applcation/service/FriendService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/friend/applcation/service/FriendService.java
@@ -38,7 +38,7 @@ public class FriendService {
 	public void followFriendByInviteCode(Long userId, FollowFriendRequest followFriendRequest) {
 		String inviteCode = followFriendRequest.inviteCode();
 		User following = userService.getUserIdByInviteCode(inviteCode);
-		User user = userService.getUserByUserId(userId);
+		User user = userService.getActiveUser(userId);
 		relationshipService.validateCanFollow(user.getId(), following.getId());
 		Friend friend = followFriendRequest.toFriend(user, following);
 		friendRepository.save(friend);

--- a/yakssok/src/main/java/server/yakssok/domain/friend/domain/repository/FriendRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/friend/domain/repository/FriendRepository.java
@@ -1,8 +1,9 @@
 package server.yakssok.domain.friend.domain.repository;
 
-import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import server.yakssok.domain.friend.domain.entity.Friend;
@@ -10,4 +11,10 @@ import server.yakssok.domain.friend.domain.entity.Friend;
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, Long>, FriendQueryRepository {
 	int countByUserId(Long userId);
+	@Modifying
+	@Query("DELETE FROM Friend f WHERE f.user.id = :userId")
+	void deleteAllByFollowingId(Long userId);
+	@Modifying
+	@Query("DELETE FROM Friend f WHERE f.following.id = :userId")
+	void deleteAllByUserId(Long userId);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/friend/presentation/controller/FriendController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/friend/presentation/controller/FriendController.java
@@ -20,6 +20,9 @@ import server.yakssok.domain.friend.presentation.dto.response.FollowingMedicatio
 import server.yakssok.domain.friend.presentation.dto.response.FollowingMedicationStatusGroupResponse;
 import server.yakssok.global.common.reponse.ApiResponse;
 import server.yakssok.global.common.security.YakssokUserDetails;
+import server.yakssok.global.common.swagger.ApiErrorResponse;
+import server.yakssok.global.common.swagger.ApiErrorResponses;
+import server.yakssok.global.exception.ErrorCode;
 
 @Tag(name = "Friend", description = "지인 API")
 @RestController
@@ -29,7 +32,12 @@ public class FriendController {
 
 	private final FriendService friendService;
 
+
 	@Operation(summary = "지인 팔로우")
+	@ApiErrorResponses(value = {
+		@ApiErrorResponse(ErrorCode.ALREADY_FRIEND),
+		@ApiErrorResponse(ErrorCode.INVALID_INVITE_CODE),
+	})
 	@PostMapping
 	public ApiResponse followByInviteCode(
 		@RequestBody FollowFriendRequest followRequest,
@@ -68,6 +76,7 @@ public class FriendController {
 		Long userId = userDetails.getUserId();
 		return ApiResponse.success(friendService.getFollowingRemainingMedication(userId));
 	}
+
 	@Operation(summary = "오늘 지인 안먹은 약 상세 조회")
 	@GetMapping("/friends/{friendId}/medication-status")
 	public ApiResponse<FollowingMedicationStatusDetailResponse> getFollowingRemainingMedicationDetail(

--- a/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/application/service/MedicationService.java
@@ -113,4 +113,15 @@ public class MedicationService {
 			.orElseThrow(() -> new MedicationException(ErrorCode.NOT_FOUND_MEDICATION));
 		return medication;
 	}
+
+	public void deleteAllByUserId(Long userId) {
+		List<Medication> medications = medicationRepository.findAllUserMedications(userId);
+		List<Long> medicationIds = medications.stream()
+			.map(Medication::getId)
+			.toList();
+		medicationIntakeDayRepository.deleteAllByMedicationIds(medicationIds);
+		medicationIntakeTimeRepository.deleteAllByMedicationIds(medicationIds);
+		medicationRepository.deleteAll(medications);
+		medicationScheduleService.deleteAllByMedicationIds(medicationIds);
+	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationIntakeDayRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationIntakeDayRepository.java
@@ -1,10 +1,18 @@
 package server.yakssok.domain.medication.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import server.yakssok.domain.medication.domain.entity.MedicationIntakeDay;
 
 @Repository
 public interface MedicationIntakeDayRepository extends JpaRepository<MedicationIntakeDay, Long> {
+	@Modifying
+	@Query("DELETE FROM MedicationIntakeDay d WHERE d.medication.id IN :medicationIds")
+	void deleteAllByMedicationIds(@Param("medicationIds") List<Long> medicationIds);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationIntakeTimeRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication/domain/repository/MedicationIntakeTimeRepository.java
@@ -1,10 +1,17 @@
 package server.yakssok.domain.medication.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import server.yakssok.domain.medication.domain.entity.MedicationIntakeTime;
 
 @Repository
 public interface MedicationIntakeTimeRepository extends JpaRepository<MedicationIntakeTime, Long> {
+	@Modifying
+	@Query("DELETE FROM MedicationIntakeTime t WHERE t.medication.id IN :medicationIds")
+	void deleteAllByMedicationIds(List<Long> medicationIds);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleManager.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleManager.java
@@ -1,6 +1,7 @@
 package server.yakssok.domain.medication_schedule.application.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +12,16 @@ import server.yakssok.domain.medication_schedule.domain.repository.MedicationSch
 public class MedicationScheduleManager {
 
 	private final MedicationScheduleRepository medicationScheduleRepository;
+
 	public void deleteTodayUpcomingSchedules(Long medicationId, LocalDateTime now) {
 		medicationScheduleRepository.deleteTodayUpcomingSchedules(
 			medicationId,
 			now.toLocalDate(),
 			now.toLocalTime()
 		);
+	}
+
+	public void deleteAllByMedicationIds(List<Long> medicationIds) {
+		medicationScheduleRepository.deleteAllByMedicationIds(medicationIds);
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/application/service/MedicationScheduleService.java
@@ -100,4 +100,8 @@ public class MedicationScheduleService {
 			medication, intakeTimes);
 		medicationScheduleJdbcRepository.batchInsert(schedules);
 	}
+
+	public void deleteAllByMedicationIds(List<Long> medicationIds) {
+		medicationScheduleManager.deleteAllByMedicationIds(medicationIds);
+	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleRepository.java
@@ -1,10 +1,17 @@
 package server.yakssok.domain.medication_schedule.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import server.yakssok.domain.medication_schedule.domain.entity.MedicationSchedule;
 
 @Repository
 public interface MedicationScheduleRepository extends JpaRepository<MedicationSchedule, Long>, MedicationScheduleQueryRepository {
+	@Modifying
+	@Query("DELETE FROM MedicationSchedule ms WHERE ms.medicationId IN :medicationIds")
+	void deleteAllByMedicationIds(List<Long> medicationIds);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/presentation/controller/MedicationScheduleController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/presentation/controller/MedicationScheduleController.java
@@ -1,5 +1,7 @@
 package server.yakssok.domain.medication_schedule.presentation.controller;
 
+import static server.yakssok.global.exception.ErrorCode.*;
+
 import java.time.LocalDate;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +21,7 @@ import server.yakssok.domain.medication_schedule.presentation.dto.response.Medic
 import server.yakssok.global.common.reponse.ApiResponse;
 import server.yakssok.global.common.security.YakssokUserDetails;
 import server.yakssok.global.common.swagger.ApiErrorResponse;
+import server.yakssok.global.common.swagger.ApiErrorResponses;
 import server.yakssok.global.exception.ErrorCode;
 
 @RestController
@@ -51,7 +54,11 @@ public class MedicationScheduleController {
 	}
 
 	@Operation(summary = "복약 스케줄 복용/미복용 처리")
-	@ApiErrorResponse(value = ErrorCode.NOT_FOUND_MEDICATION_SCHEDULE)
+	@ApiErrorResponses(value = {
+		@ApiErrorResponse(value = NOT_FOUND_MEDICATION_SCHEDULE),
+		@ApiErrorResponse(value = FORBIDDEN),
+		@ApiErrorResponse(ErrorCode.NOT_TODAY_SCHEDULE)
+	})
 	@PutMapping("/{scheduleId}/take")
 	public ApiResponse switchTakeMedication(
 		@AuthenticationPrincipal YakssokUserDetails userDetails,

--- a/yakssok/src/main/java/server/yakssok/domain/notification/presentation/dto/response/NotificationResponse.java
+++ b/yakssok/src/main/java/server/yakssok/domain/notification/presentation/dto/response/NotificationResponse.java
@@ -34,12 +34,21 @@ public record NotificationResponse(
 	@Schema(description = "내가 보낸 알림 여부", example = "false")
 	boolean isSentByMe
 ) {
-	public static final String SYSTEM_SENDER_NAME = "약쏙";
+	private static final String SYSTEM_SENDER_NAME = "약쏙";
+	private static final String DELETED_USER_NAME = "알 수 없음";
+
+	private static String getUserNickName(User user) {
+		if (user.isDeleted())
+			return DELETED_USER_NAME;
+		else
+			return user.getNickName();
+	}
+
 
 	public static NotificationResponse ofFeedbackNotification(Notification notification, User sender, User receiver, boolean isSentByMe) {
-		String senderNickName = sender.getNickName();
+		String senderNickName = getUserNickName(sender);
 		String senderProfileUrl = sender.getProfileImageUrl();
-		String receiverNickName = receiver.getNickName();
+		String receiverNickName = getUserNickName(receiver);
 		String receiverProfileUrl = receiver.getProfileImageUrl();
 		String body = notification.getBody();
 
@@ -57,7 +66,7 @@ public record NotificationResponse(
 	}
 
 	public static NotificationResponse ofSystemNotification(Notification notification, User receiver) {
-		String receiverNickName = receiver.getNickName();
+		String receiverNickName = getUserNickName(receiver);
 		String receiverProfileUrl = receiver.getProfileImageUrl();
 		String title = notification.getTitle();
 		String body = notification.getBody();

--- a/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserDeletionService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserDeletionService.java
@@ -1,0 +1,42 @@
+package server.yakssok.domain.user.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import server.yakssok.domain.auth.application.service.RefreshTokenService;
+import server.yakssok.domain.friend.domain.repository.FriendRepository;
+import server.yakssok.domain.medication.application.service.MedicationService;
+import server.yakssok.domain.user.domain.entity.User;
+import server.yakssok.domain.user.domain.repository.UserDeviceRepository;
+@Service
+@RequiredArgsConstructor
+public class UserDeletionService {
+	private final FriendRepository friendRepository;
+	private final MedicationService medicationService;
+	private final RefreshTokenService refreshTokenService;
+	private final UserDeviceRepository userDeviceRepository;
+
+	@Transactional
+	public void deleteUser(User user) {
+		Long userId = user.getId();
+		deleteAllUserInfo(user, userId);
+		deleteUserAllMedications(userId);
+		deleteAllFriend(userId);
+	}
+
+	private void deleteUserAllMedications(Long userId) {
+		medicationService.deleteAllByUserId(userId);
+	}
+
+	private void deleteAllUserInfo(User user, Long userId) {
+		user.deactivate();
+		refreshTokenService.deleteRefreshToken(userId);
+		userDeviceRepository.deleteAllByUserId(userId);
+	}
+
+	private void deleteAllFriend(Long userId) {
+		friendRepository.deleteAllByUserId(userId);
+		friendRepository.deleteAllByFollowingId(userId);
+	}
+}

--- a/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserDeviceService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserDeviceService.java
@@ -17,7 +17,7 @@ public class UserDeviceService {
 	private final UserService userService;
 
 	public void registerOrUpdateDevice(Long userId, RegisterDeviceRequest request) {
-		User user = userService.getUserByUserId(userId);
+		User user = userService.getActiveUser(userId);
 		Optional<UserDevice> existing = userDeviceRepository.findByUserIdAndDeviceId(userId, request.deviceId());
 
 		if (existing.isPresent()) {

--- a/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserService.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/application/service/UserService.java
@@ -63,4 +63,15 @@ public class UserService {
 			.orElseThrow(() -> new UserException(ErrorCode.INVALID_INVITE_CODE));
 		return user;
 	}
+
+	@Transactional
+	public void deleteUser(Long userId) {
+		/**
+		 * 나의 복약 정보 삭제
+		 * 나의 복약 스케줄 삭제
+		 * 내가 팔로우하는 사람 팔로우 끊기
+		 * 나를 팔로우 하는 사람 팔로우 끊기
+		 * 내가 보낸 잔소리, 나에게 보낸 잔소리??? 그리고 알림은
+		 */
+	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/domain/entity/User.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/domain/entity/User.java
@@ -24,7 +24,6 @@ public class User extends BaseEntity {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false)
 	private String nickName;
 	private String profileImageUrl;
 
@@ -34,8 +33,9 @@ public class User extends BaseEntity {
 	private String providerId;
 
 	@Embedded
-	@AttributeOverride(name = "value", column = @Column(name = "invite_code", unique = true, nullable = false, length = 20))
+	@AttributeOverride(name = "value", column = @Column(name = "invite_code", unique = true, length = 20))
 	private InviteCode inviteCode;
+	private boolean isDeleted;
 
 	private User(String nickName, String profileImageUrl, OAuthType oAuthType, String providerId, InviteCode inviteCode) {
 		this.nickName = nickName;
@@ -58,5 +58,14 @@ public class User extends BaseEntity {
 	public void updateInfo(String nickname, String profileImageUrl) {
 		this.nickName = nickname;
 		this.profileImageUrl = profileImageUrl;
+	}
+
+	public void deactivate() {
+		this.nickName = null;
+		this.profileImageUrl = null;
+		this.oAuthType = null;
+		this.providerId = null;
+		this.inviteCode = null;
+		this.isDeleted = true;
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/domain/repository/UserDeviceRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/domain/repository/UserDeviceRepository.java
@@ -4,10 +4,15 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import server.yakssok.domain.user.domain.entity.UserDevice;
 
 public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
 	List<UserDevice> findByUserIdAndAlertOnTrue(Long userId);
 	Optional<UserDevice> findByUserIdAndDeviceId(Long userId, String deviceId);
+	@Modifying
+	@Query("DELETE FROM UserDevice ud WHERE ud.user.id = :userId")
+	void deleteAllByUserId(Long userId);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/domain/repository/UserRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/domain/repository/UserRepository.java
@@ -10,4 +10,5 @@ import server.yakssok.domain.user.domain.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepository {
 	Optional<User> findByInviteCodeValue(String inviteCode);
+	Optional<User> findByIdAndIsDeletedFalse(Long userId);
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/presentation/controller/UserController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/presentation/controller/UserController.java
@@ -1,8 +1,8 @@
 package server.yakssok.domain.user.presentation.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +16,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import server.yakssok.domain.user.application.service.UserDeviceService;
 import server.yakssok.domain.user.application.service.UserService;
-import server.yakssok.domain.user.presentation.dto.request.RegisterDeviceRequest;
 import server.yakssok.domain.user.presentation.dto.response.FindUserInfoResponse;
 import server.yakssok.domain.user.presentation.dto.request.UpdateUserInfoRequest;
 import server.yakssok.domain.user.presentation.dto.response.FindMyInfoResponse;
@@ -74,5 +73,16 @@ public class UserController {
 		@RequestParam String inviteCode
 	) {
 		return ApiResponse.success(userService.findUserInfoByInviteCode(inviteCode));
+	}
+
+	@Operation(summary = "회원 탈퇴")
+	@ApiErrorResponse(ErrorCode.NOT_FOUND_USER)
+	@DeleteMapping
+	public ApiResponse deleteUser(
+		@AuthenticationPrincipal YakssokUserDetails userDetails
+	) {
+		Long userId = userDetails.getUserId();
+		userService.deleteUser(userId);
+		return ApiResponse.success();
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/user/presentation/controller/UserController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/user/presentation/controller/UserController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import server.yakssok.domain.user.application.service.UserDeviceService;
 import server.yakssok.domain.user.application.service.UserService;
 import server.yakssok.domain.user.presentation.dto.response.FindUserInfoResponse;
 import server.yakssok.domain.user.presentation.dto.request.UpdateUserInfoRequest;
@@ -31,7 +30,6 @@ import server.yakssok.global.exception.ErrorCode;
 @Tag(name = "User", description = "유저 API")
 public class UserController {
 	private final UserService userService;
-	private final UserDeviceService userDeviceService;
 
 	@Operation(summary = "내 정보 조회")
 	@ApiErrorResponse(ErrorCode.NOT_FOUND_USER)

--- a/yakssok/src/main/java/server/yakssok/global/common/jwt/JwtAuthService.java
+++ b/yakssok/src/main/java/server/yakssok/global/common/jwt/JwtAuthService.java
@@ -7,9 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.security.core.Authentication;
 import lombok.RequiredArgsConstructor;
 import server.yakssok.domain.auth.application.exception.AuthException;
+import server.yakssok.domain.user.application.service.UserService;
 import server.yakssok.domain.user.domain.entity.User;
-import server.yakssok.domain.user.application.exception.UserException;
-import server.yakssok.domain.user.domain.repository.UserRepository;
 import server.yakssok.global.common.security.YakssokUserDetails;
 import server.yakssok.global.exception.ErrorCode;
 
@@ -17,7 +16,7 @@ import server.yakssok.global.exception.ErrorCode;
 @RequiredArgsConstructor
 public class JwtAuthService {
 	private final JwtTokenUtils jwtTokenUtils;
-	private final UserRepository userRepository;
+	private final UserService userService;
 
 	public Authentication getAuthentication(String token) {
 		if (!jwtTokenUtils.isValidateToken(token)) {
@@ -25,8 +24,7 @@ public class JwtAuthService {
 		}
 
 		Long userId = jwtTokenUtils.getIdFromJwt(token);
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+		User user = userService.getActiveUser(userId);
 
 		UserDetails principal = new YakssokUserDetails(user.getId());
 		return new UsernamePasswordAuthenticationToken(

--- a/yakssok/src/main/java/server/yakssok/global/common/swagger/ApiErrorResponseCustomizer.java
+++ b/yakssok/src/main/java/server/yakssok/global/common/swagger/ApiErrorResponseCustomizer.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
@@ -29,22 +30,45 @@ public class ApiErrorResponseCustomizer implements OperationCustomizer {
 		ApiErrorResponses multiple = handlerMethod.getMethodAnnotation(ApiErrorResponses.class);
 		if (multiple != null) errorAnnotations.addAll(Arrays.asList(multiple.value()));
 
+		Map<String, ApiResponse> statusToApiResponse = new HashMap<>();
+
 		for (ApiErrorResponse error : errorAnnotations) {
 			ErrorCode errorCode = error.value();
-			Map<String, Object> example = new HashMap<>();
-			example.put("code", errorCode.getCode());
-			example.put("message", errorCode.getMessage());
-			example.put("body", new HashMap<>());
+			String status = String.valueOf(errorCode.getHttpStatus());
 
-			ApiResponse apiResponse = new ApiResponse()
-				.description(errorCode.getMessage())
-				.content(new Content().addMediaType("application/json",
-					new MediaType()
-						.schema(new Schema<>().$ref("#/components/schemas/ApiResponse"))
-						.example(example)));
+			// 예시 데이터
+			Map<String, Object> exampleValue = new HashMap<>();
+			exampleValue.put("code", errorCode.getCode());
+			exampleValue.put("message", errorCode.getMessage());
+			exampleValue.put("body", new HashMap<>());
 
-			operation.getResponses().addApiResponse(String.valueOf(errorCode.getHttpStatus()), apiResponse);
+			// ApiResponse를 status별로 관리
+			ApiResponse apiResponse = statusToApiResponse.get(status);
+			if (apiResponse == null) {
+				apiResponse = new ApiResponse()
+					.description("에러 응답"); // 여러 에러라면 통합 메시지 사용
+				// 기본 Content 및 MediaType 세팅
+				Content content = new Content();
+				MediaType mediaType = new MediaType()
+					.schema(new Schema<>().$ref("#/components/schemas/ApiResponse"));
+				content.addMediaType("application/json", mediaType);
+				apiResponse.setContent(content);
+				statusToApiResponse.put(status, apiResponse);
+			}
+
+			// 여러 예시 등록 (code 이름으로 구분)
+			MediaType mediaType = apiResponse.getContent().get("application/json");
+			if (mediaType.getExamples() == null) {
+				mediaType.setExamples(new HashMap<>());
+			}
+			Example example = new Example().value(exampleValue).summary(errorCode.getMessage());
+			mediaType.getExamples().put(errorCode.name(), example);
 		}
+
+		for (Map.Entry<String, ApiResponse> entry : statusToApiResponse.entrySet()) {
+			operation.getResponses().addApiResponse(entry.getKey(), entry.getValue());
+		}
+
 		return operation;
 	}
 }


### PR DESCRIPTION
## 💻 작업 내용
- 회원 탈퇴 
- 회원 탈퇴 시 잔소리와 알림, 유저 테이블을 제외한 모든 테이블 데이터 삭제, 유저 테이블의 PK를 제외한 모든 정보 null 처리
  
  <img width="1922" height="1386" alt="image" src="https://github.com/user-attachments/assets/1193ccac-e5a3-4c8a-97f4-c6ffe599c7b8" />

- 알림 조회 시 탈퇴한 유저의 경우 "알수없음"이라는 이름으로 내려주고 있는데 프론트와 논의 후 수정 필요할 수도...🤔
- 스웨거 같은 httpStatus의 경우 덮어쓰기 되어 누락되는 문제 -> 커스컴 에러 code에 따라 example을 볼 수 있도록 변경 

## 🗒️ 참고자료
