### PR TITLE
[YSS-64] 칭찬/잔소리 대상 조회 로직 변경

### DIFF
--- a/yakssok/src/main/java/server/yakssok/domain/friend/presentation/controller/FriendController.java
+++ b/yakssok/src/main/java/server/yakssok/domain/friend/presentation/controller/FriendController.java
@@ -78,12 +78,12 @@ public class FriendController {
 	}
 
 	@Operation(summary = "오늘 지인 안먹은 약 상세 조회")
-	@GetMapping("/friends/{friendId}/medication-status")
+	@GetMapping("/{followingId}/medication-status")
 	public ApiResponse<FollowingMedicationStatusDetailResponse> getFollowingRemainingMedicationDetail(
 		@AuthenticationPrincipal YakssokUserDetails userDetails,
-		@PathVariable Long friendId
+		@PathVariable Long followingId
 	) {
 		Long userId = userDetails.getUserId();
-		return ApiResponse.success(friendService.getFollowingRemainingMedicationDetail(userId, friendId));
+		return ApiResponse.success(friendService.getFollowingRemainingMedicationDetail(userId, followingId));
 	}
 }

--- a/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepository.java
+++ b/yakssok/src/main/java/server/yakssok/domain/medication_schedule/domain/repository/MedicationScheduleQueryRepository.java
@@ -12,8 +12,8 @@ public interface MedicationScheduleQueryRepository {
 	List<MedicationScheduleDto> findUserSchedulesByDate(Long userId, LocalDate date);
 	List<MedicationScheduleDto> findUserSchedulesInPastRange(Long userId, LocalDate startDate, LocalDate endDate);
 	void deleteTodayUpcomingSchedules(Long medicationId, LocalDate currentDate, LocalTime currentTime);
-	List<Long> findFollowingIdsWithTodaySchedule(List<Long> followingIds, LocalDate now);
-	Map<Long, Integer> countTodayRemainingMedications(List<Long> followingIdsWithTodaySchedule, LocalDate now);
-	List<MedicationScheduleDto> findRemainingMedicationDetail(Long friendId, LocalDate now);
+	List<Long> findUserIdsWithAllTakenToday(List<Long> followingIds, LocalDate now);
+	Map<Long, Integer> countTodayRemainingMedications(List<Long> followingIdsWithTodaySchedule, LocalDateTime now);
+	List<MedicationScheduleDto> findRemainingMedicationDetail(Long friendId, LocalDateTime now);
 	List<MedicationScheduleAlarmDto> findNotTakenSchedules(LocalDateTime notTakenLimitTime);
 }


### PR DESCRIPTION
## 💻 작업 내용
- 칭찬, 잔소리 대상 유저 목록 조회 로직 변경
- 잔소리 대상 : 현재 시간 이전의 스케줄 중에서 미복용 상태 스케줄이 있는 경우
- 칭찬 대상 : 오늘 스케줄이 모두 복용 상태인 경우

## 나중에 고민해야 할 것들
- 칭찬 대상 유저 조회 시 having절 피할 방법 (having절 성능 이슈)